### PR TITLE
feat: Implement user data deletion before cloud sync in PhysicalParam…

### DIFF
--- a/TIMESTAMP_FIX_SUMMARY.md
+++ b/TIMESTAMP_FIX_SUMMARY.md
@@ -1,0 +1,122 @@
+# Timestamp Preservation Fix
+
+## 🐛 Problem Identified
+
+The cloud sync was working but **showing wrong data as "latest"** because:
+
+### Root Cause
+When multiple entries were uploaded for the same day, the cloud database was keeping outdated timestamps:
+
+**What Was Happening:**
+1. Phone A uploads at 09:00 AM → Cloud stores with timestamp 09:00 AM
+2. Phone A uploads again at 05:00 PM → Cloud **overwrites** with timestamp 05:00 PM
+3. But Phone B had local entries created at 06:00 PM
+4. Phone B sees: Local 06:00 PM > Cloud 05:00 PM
+5. Phone B shows local data instead of cloud data ❌
+
+## ✅ Fixes Applied
+
+### Fix 1: Server-Side - Preserve Newer Timestamps
+
+**File:** `server/src/routes/body.js`
+
+**Before:**
+```javascript
+UPDATE physical_parameters 
+SET date = $2, weight = $3, ...  // Always overwrites timestamp
+WHERE id = $1
+```
+
+**After:**
+```javascript
+UPDATE physical_parameters 
+SET date = CASE 
+  WHEN date < $2 THEN $2  -- Use newer timestamp
+  ELSE date  -- Keep existing if it's newer
+END,
+weight = $3, height = $4, ...
+WHERE id = $1
+```
+
+**Result:** Cloud always keeps the **latest timestamp** for each day's entry.
+
+### Fix 2: Client-Side - Clear Local Data Before Download
+
+**File:** `app/src/main/java/com/example/gymtracker/viewmodels/PhysicalParametersViewModel.kt`
+
+**Added:**
+```kotlin
+// Clear all local data before syncing from cloud
+physicalParametersDao.deleteAllBodyMeasurementsForUser(userId)
+physicalParametersDao.deleteAllPhysicalParametersForUser(userId)
+
+// Then download and save cloud data
+repository.getPhysicalParameters()
+```
+
+**Result:** Cloud data becomes the **source of truth** when downloading.
+
+### Fix 3: DAO - Added Deletion Methods
+
+**File:** `app/src/main/java/com/example/gymtracker/data/PhysicalParametersDao.kt`
+
+**Added:**
+```kotlin
+@Query("DELETE FROM physical_parameters WHERE userId = :userId")
+suspend fun deleteAllPhysicalParametersForUser(userId: String)
+
+@Query("DELETE FROM body_measurements WHERE parametersId IN (...)")
+suspend fun deleteAllBodyMeasurementsForUser(userId: String)
+```
+
+## 🎯 How It Works Now
+
+### Upload from Phone A
+```
+1. User enters: 77kg, 150cm at 17:28:00
+2. Uploads to cloud
+3. Cloud checks: Existing timestamp vs new timestamp
+4. Cloud keeps NEWER timestamp (17:28:00)
+5. Cloud stores: 77kg, 150cm, timestamp=17:28:00 ✅
+```
+
+### Download on Phone B
+```
+1. User clicks download button
+2. App CLEARS all local data for this user
+3. App downloads from cloud
+4. Cloud returns: 77kg, 150cm, timestamp=17:28:00
+5. App saves to local with cloud timestamp
+6. UI shows: 77kg, 150cm ✅
+```
+
+## ⚠️ Important Behavior Change
+
+**Download now REPLACES local data** instead of merging:
+- ✅ Good: Ensures cloud data is shown correctly
+- ⚠️ Warning: Any un-uploaded local data will be lost
+
+**Best Practice for Users:**
+1. Always **UPLOAD** before switching devices
+2. Use **DOWNLOAD** only when you want to restore from cloud
+3. Upload = Backup | Download = Restore
+
+## 🚀 Alternative Approach (For Future)
+
+A more sophisticated sync could:
+1. **Compare timestamps** of local vs cloud data
+2. **Merge** intelligently (keep newest data from either source)
+3. **Conflict resolution** when data differs for same timestamp
+4. **Two-way sync** instead of one-way replace
+
+But for now, the "download = restore from cloud" approach is simpler and safer.
+
+## ✅ Testing
+
+After deploying these changes:
+
+**Test Scenario:**
+1. Phone A: Add 77kg, 150cm → Upload
+2. Phone B: Click Download
+3. Expected: Phone B shows 77kg, 150cm
+4. Result: ✅ Should work correctly now!

--- a/app/src/main/java/com/example/gymtracker/data/PhysicalParametersDao.kt
+++ b/app/src/main/java/com/example/gymtracker/data/PhysicalParametersDao.kt
@@ -58,6 +58,14 @@ interface PhysicalParametersDao {
 
     @Query("SELECT AVG(weight) FROM physical_parameters WHERE userId = :userId AND weight IS NOT NULL")
     suspend fun getAverageWeight(userId: String): Float?
+    
+    // Delete all physical parameters for a user (for cloud sync replacement)
+    @Query("DELETE FROM physical_parameters WHERE userId = :userId")
+    suspend fun deleteAllPhysicalParametersForUser(userId: String)
+    
+    // Delete all body measurements for a user (cascade will happen via foreign key, but this is explicit)
+    @Query("DELETE FROM body_measurements WHERE parametersId IN (SELECT id FROM physical_parameters WHERE userId = :userId)")
+    suspend fun deleteAllBodyMeasurementsForUser(userId: String)
 }
 
 // Data class to combine physical parameters with body measurements

--- a/app/src/main/java/com/example/gymtracker/viewmodels/PhysicalParametersViewModel.kt
+++ b/app/src/main/java/com/example/gymtracker/viewmodels/PhysicalParametersViewModel.kt
@@ -297,6 +297,13 @@ class PhysicalParametersViewModel(
             try {
                 Log.d("PhysicalParametersViewModel", "Starting sync from cloud for userId: $userId")
                 
+                // Clear all local data for this user before syncing from cloud
+                // This ensures cloud data is the source of truth
+                Log.d("PhysicalParametersViewModel", "Clearing local data for user: $userId")
+                physicalParametersDao.deleteAllBodyMeasurementsForUser(userId)
+                physicalParametersDao.deleteAllPhysicalParametersForUser(userId)
+                Log.d("PhysicalParametersViewModel", "Local data cleared successfully")
+                
                 // Sync physical parameters from cloud
                 val parametersResult = repository.getPhysicalParameters()
                 if (parametersResult.isSuccess) {


### PR DESCRIPTION
…etersViewModel

- Added methods in PhysicalParametersDao to delete all physical parameters and body measurements for a user, ensuring a clean slate before syncing data from the cloud.
- Updated PhysicalParametersViewModel to clear local data for the user prior to initiating cloud synchronization, reinforcing the cloud as the source of truth.