### PR TITLE
fix: Adjust body measurement ID handling for new measurements

### DIFF
--- a/app/src/main/java/com/example/gymtracker/services/BodySyncRepository.kt
+++ b/app/src/main/java/com/example/gymtracker/services/BodySyncRepository.kt
@@ -302,7 +302,7 @@ class BodySyncRepository(private val context: Context) {
     
     fun convertToBodyMeasurementRequest(local: BodyMeasurement): BodyMeasurementRequest {
         return BodyMeasurementRequest(
-            id = local.id,
+            id = if (local.id > 0) local.id else null, // Send null for new measurements (ID <= 0)
             parametersId = local.parametersId,
             measurementType = local.measurementType,
             value = local.value,


### PR DESCRIPTION
- Updated BodySyncRepository to send null for new measurements with ID <= 0, ensuring proper handling during sync.
- Enhanced server-side logic to attempt updating existing measurements first, and insert new records if none are found, improving data integrity during synchronization.